### PR TITLE
Made it so that download app popup should only come after login

### DIFF
--- a/components/modals/DownloadPlayModal.tsx
+++ b/components/modals/DownloadPlayModal.tsx
@@ -1,6 +1,7 @@
 import { Theme, useTheme } from "@react-navigation/native";
 import { useEffect, useMemo, useState } from "react";
 
+import { useAuthContext } from "@/contexts";
 import { useBreakpoints } from "@/hooks";
 import { CREATORS_PLAYSTORE_URL } from "@/shared-constants/app";
 import BottomSheetContainer from "@/shared-uis/components/bottom-sheet";
@@ -16,12 +17,18 @@ const DownloadPlayModal: React.FC<DownloadPlayModalProps> = ({ }) => {
   const theme = useTheme();
   const styles = stylesFn(theme);
   const [isVisible, setIsVisible] = useState(false);
+  const { user } = useAuthContext()
+  const [displayedOnce, setDisplayedOnce] = useState(false)
 
   useEffect(() => {
+    if (!user || !user.primarySocial || displayedOnce)
+      return
+
+    setDisplayedOnce(true)
     setTimeout(() => {
       setIsVisible(true);
     }, 5000);
-  }, [])
+  }, [user])
 
   const {
     lg,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved modal behavior to ensure it only appears once and only when user and social information are available. Modal will no longer show unnecessarily or multiple times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->